### PR TITLE
Use npm-run-all to simplify npm scripts

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -63,16 +63,17 @@ As a tip, consider adding the following NPM scripts to your `package.json` file,
 ```js
 "scripts": {
     "dev": "npm run development",   
-    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "development": "cross-env NODE_ENV=development run-s mix",
+    "watch": "cross-env NODE_ENV=development run-s \"mix --watch\"",
     "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",   
     "prod": "npm run production",
-    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "production": "cross-env NODE_ENV=production run-s mix",
+    "mix": "webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
 }
 ```
 
-To handle different environments, these scripts make use of [cross-env](https://www.npmjs.com/package/cross-env):
+To handle different environments, these scripts make use of [cross-env](https://www.npmjs.com/package/cross-env) and [npm-run-all](https://www.npmjs.com/package/npm-run-all):
 
 ```bash
-npm install cross-env --save-dev
+npm install cross-env npm-run-all --save-dev
 ```


### PR DESCRIPTION
This also changes `node_modules/webpack/bin/webpack.js` to just `webpack`. The examples already do this with `webpack-dev-server` so for consistency let’s do it with `webpack` as well.

A further suggestion would be to change:

```json
 "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
```

to

```json
 "hot": "cross-env NODE_ENV=development run-s development mix:hot",   
 "mix:hot": "webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",   
```

since `hot` doesn’t work if the `publicPath` doesn’t exist (`hot` will be in the `publicPath`, e.g. `dist/hot`).