### PR TITLE
Add hint about concatenation (and Babel) to the JS docs page

### DIFF
--- a/mixjs.md
+++ b/mixjs.md
@@ -130,5 +130,5 @@ Of course, you'll still want to do the necessary tweeks like creating `tsconfig.
 
 ### Plain JavaScript and Minification
 
-If you do not need complex building with Vue, React or Typescript support you can also use plain JavaScript concatenation and minification. There is also support for Babel available to get the most basic stuff done.  
+If you do not need support for complex  with Vue, React or Typescript build tasks you can also use plain JavaScript concatenation and minification. There is also support for Babel available to get the most basic stuff done.  
 For more information, see the [Concatenation and Minification](concatenation-and-minification) documentation.

--- a/mixjs.md
+++ b/mixjs.md
@@ -126,3 +126,9 @@ mix.ts('resources/assets/js/app.ts', 'public/js/app.js');
 ```
 
 Of course, you'll still want to do the necessary tweeks like creating `tsconfig.json` file and installing [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped), but everything else should be taken care of.
+
+
+### Plain JavaScript and Minification
+
+If you do not need complex building with Vue, React or Typescript support you can also use plain JavaScript concatenation and minification. There is also support for Babel available to get the most basic stuff done.  
+For more information, see the [Concatenation and Minification](concatenation-and-minification) documentation.


### PR DESCRIPTION
For me as a starter it was very difficult to get my JS configuration up and running. The problem is that I did not use Vue or React in the first project and Laravel Mix just started to put a huge overhead into my builds which I guess came from Webpack and Vue.
It took some time until I discovered the `babel()` method in the official Laravel documentation that reduced the JS output to the bare minimum. Therefore I added a simple hint to the JS page that points new users to the concatenation and minification page.