### PR TITLE
Add reference to `inProduction` method

### DIFF
--- a/versioning.md
+++ b/versioning.md
@@ -57,3 +57,13 @@ mix.version(['public/js/random.js']);
 ```
 
 Now, we'll still version any relevant compiled files, but we'll also append a query string, `public/js/random.js?{hash}`, and update your `mix-manifest.json` file.
+
+### Optionally versioning files
+
+Because versioned files are usually unnecessary in development, you may instruct the versioning process to only run during npm run production:  
+
+```js
+if (mix.inProduction()) {
+    mix.version();
+}
+```


### PR DESCRIPTION
This very helpful method is referred to in the Laravel docs but not on laravel-mix.com and could be overlooked by those who use Mix on stand-alone projects :)