### PR TITLE
Improve standalone installation instructions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -46,7 +46,7 @@ mix.js('src/app.js', 'dist')
 
 Take note of the source paths. You're free to amend the paths to match your preferred structure, but if you're happy with our defaults simply run `mkdir src && touch src/app.{js,scss}` to create the files/directories.  
 You're all set now.  
-Compile everything down by running `node_modules/.bin/webpack` from the command line.
+Compile everything down by running `node_modules/.bin/webpack --config=node_modules/laravel-mix/setup/webpack.config.js` from the command line.
 
 You should now see:
 


### PR DESCRIPTION
[Some users (including me) have experienced issues with the initial install instructions when running webpack directly](https://github.com/JeffreyWay/laravel-mix/issues/1904#issuecomment-451061468). Explicitly passing the config file solves this, so I've added that to the instructions.