### PR TITLE
Add small section about new node minimum to the upgrade page

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -1,6 +1,7 @@
 # Upgrade to Mix 6
 
 -   [Review Your Dependencies](#review-your-dependencies)
+-   [The New Node Minimum](#the-new-node-minimum)
 -   [Update Your NPM Scripts](#update-your-npm-scripts)
 -   [Watch Ignores node_modules](#watch-ignores-node-modules)
 -   [API for JavaScript Frameworks](#api-for-javascript-frameworks)
@@ -19,6 +20,10 @@ Laravel Mix 6 ships with support for the latest versions of numerous dependencie
 These are significant releases with their own sets of breaking changes. We've done our best to normalize these changes, but it's still particularly important that you take the time to fully test your build after upgrading to Mix 6.
 
 Please review your `package.json` dependencies list for any third-party tools or plugins that may not yet be compatible with webpack 5 or PostCSS 8.
+
+## The New Node Minimum
+
+With Laravel Mix 6, the underlying minimum requirements of Node has been updated to a new minimum, make sure you have atleast `v12.14.0` installed.
 
 ## Update Your NPM Scripts
 


### PR DESCRIPTION
Hello there. 👋

I've noticed there isn't any mention of the new minimum requirements of which node version an end-user should have installed to have `mix` work. This is a bit odd since the new requirements have been bumped up 4 versions, from `8.9.0` to `12.14.0`. Figured adding a small section about it would be a nice thing to do for users updating. 🤔

![Screen Shot 2021-01-19 at 7 15 52 AM](https://user-images.githubusercontent.com/2221746/104995285-54080180-5a26-11eb-9df6-8ac8359fcad8.png)
