### PR TITLE
Updated npm install command to target '@latest'

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -10,7 +10,7 @@
 -   [Automatically Ignored node_modules](#automatically-ignore-node-modules)
 
 ```bash
-npm install laravel-mix@next
+npm install laravel-mix@latest
 ```
 
 ## Review Your Dependencies


### PR DESCRIPTION
Updated the `npm install` command to `@latest` instead of `@next` to prevent updating to non-stable versions.